### PR TITLE
Add support for version 4.9 of contao/core-bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 .project
 composer.lock
 vendor
+.idea/
 # Transifex
 /.tx/

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require":{
     "php": "^7.4 || ^8.0",
-    "contao/core-bundle": "^4.9 || ~4.13",
+    "contao/core-bundle": "^4.9",
     "contao-community-alliance/composer-plugin":"~3.2"
   },
   "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require":{
     "php": "^7.4 || ^8.0",
-    "contao/core-bundle": "~4.13",
+    "contao/core-bundle": "^4.9 || ~4.13",
     "contao-community-alliance/composer-plugin":"~3.2"
   },
   "conflict": {


### PR DESCRIPTION
This PR adds support for version 4.9 of contao/core-bundle.